### PR TITLE
Fix: Correct typos and grammar in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@
 
 
 ## About
-Strongly typed **union type** in golang with generics*.
+Strongly typed **union type** in golang that supports generics*.
 
 * with exhaustive _pattern matching_ support
 * with _json marshalling_ including generics
-* and as a bonus, can generate compatible typescript types for end-to-end type safety in your application
+* and as a bonus, can generate compatible TypeScript types for end-to-end type safety in your application
 
 ## Why
-Historically in languages without union types like golang, unions were solved either by using Visitor pattern, or using `iota` and `switch` statement, or other workarounds.
+Historically, in languages like Go that lack native union types, developers have resorted to workarounds such as the Visitor pattern or `iota` with `switch` statements.
 
-Visitor pattern requires a lot of boiler plate code and hand crafting of the `Accept` method for each type in the union.
-`iota` and `switch` statement is not type safe and can lead to runtime errors, especially when new type is added and not all `case` statements are updated.
+The Visitor pattern requires a lot of boilerplate code and manual crafting of the `Accept` method for each type in the union.
+Using `iota` and `switch` statements is not type-safe and can lead to runtime errors, especially when a new type is added and not all `case` statements are updated.
 
-On top of that, any data marshalling like to/from JSON requires additional, hand crafted code, to make it work.
+On top of that, any data marshalling, like to/from JSON, requires additional, handcrafted code to make it work.
 
-MkUnion solves all of those problems, by generating opinionated and strongly typed meaningful code for you.
+MkUnion solves all of these problems by generating opinionated and strongly typed, meaningful code for you.
 
 ## Example
 
@@ -82,4 +82,5 @@ func ExampleFromJSON() {
 
 ## Next
 
-- Read [getting started](https://widmogrod.github.io/mkunion/getting_started/)  to learn more.
+- Read [getting started](https://widmogrod.github.io/mkunion/getting_started/) to learn more.
+- Or to understand better concepts jump and read [value proposition](./docs/value_proposition.md)

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -5,20 +5,20 @@ title: Contributing and development
 # Contributing and development
 ## Contributing
 
-If you want to contribute to `mkunion` project, please open issue first to discuss your idea.
+If you want to contribute to the `mkunion` project, please open an issue first to discuss your idea.
 
 I have opinions about how `mkunion` should work, how I want to evolve it, and I want to make sure that your idea fits into the project.
 
 ## Development
 
-Checkout repo and run:
+Checkout the repo and run:
 ```
 ./dev/bootstrap.sh
 ```
 
-This command starts docker container with all necessary tools to develop and test `mkunion` project.
+This command starts a Docker container with all the necessary tools to develop and test the `mkunion` project.
 
-In separate terminal run:
+In a separate terminal, run:
 ```
 go generate ./...
 go test ./...
@@ -26,11 +26,11 @@ go test ./...
 
 This will generate code and run tests.
 
-Note: Some tests are flaky (yes I know, I'm working on it), so if you see some test failing, please run it again.
+Note: Some tests may be flaky (this is a known issue being addressed). If you encounter a failing test, please try running it again.
 
 ## Documentation
 
-To preview documentation run:
+To preview the documentation, run:
 ```
  ./dev/docs.sh run
 ```

--- a/docs/examples/generic_union.md
+++ b/docs/examples/generic_union.md
@@ -5,11 +5,11 @@ title: Union and generic types
 MkUnion will generate generic unions for you.
 
 You only need to declare each variant type of the union with a type parameter,
-and library will figure out the rest.
+and the library will figure out the rest.
 
 What is **IMPORTANT** is that each variant type (Branch, Leaf in this example) needs to have the same number of type parameters.
 
-For example, let's say you want to create a recursive tree data structure, that in leaves will hold value of `A` type.
+For example, let's say you want to create a recursive tree data structure, that in its leaves will hold a value of `A` type.
 
 ## Declaration and generation
 
@@ -30,7 +30,7 @@ you have access to the same features as with non-generic unions.
 
 ## Matching function
 
-Let's define higher order function `ReduceTree` that will travers leaves in `Tree` and produce a single value.
+Let's define a higher-order function `ReduceTree` that will traverse leaves in `Tree` and produce a single value.
 
 This function uses `MatchTreeR1` function that is generated automatically for you.
 
@@ -72,7 +72,7 @@ func ExampleTreeSumValues() {
 }
 ```
 
-You can also reduce tree to complex structure, for example to keep track of order of values in the tree, along with sum of all values in the tree.
+You can also reduce the tree to a complex structure, for example, to keep track of the order of values in the tree, along with the sum of all values in the tree.
 
 ```go title="example/tree_test.go"
 func ExampleTreeCustomReduction() {
@@ -105,10 +105,10 @@ func ExampleTreeCustomReduction() {
 
 ## Either & Option types
 
-For educational purposes, let's create two most popular union types in functional languages: `Option` and `Either` with corresponding `Map` functions.
+For educational purposes, let's create two of the most popular union types in functional languages: `Option` and `Either`, with corresponding `Map` functions.
 
-- Either type is used to represent one of two possible values. Many times left value holds success value, and right value holds error value.
-- Option type is used to represent a value that may or may not be present. Replaces nulls in some languages.
+- The Either type is used to represent one of two possible values. Many times the left value holds the success value, and the right value holds an error value.
+- The Option type is used to represent a value that may or may not be present, often replacing nulls in other languages.
 
 ```go title="f/datas.go"
 //go:tag mkunion:"Either"
@@ -148,9 +148,9 @@ func MapOption[A, B any](x Option[A], f func(A) B) Option[B] {
 }
 ```
 
-In above example, we define `MapEither` and `MapOption` functions that will apply function `f` to value inside `Either` or `Option` type.
+In the example above, we define `MapEither` and `MapOption` functions that will apply the function `f` to the value inside the `Either` or `Option` type.
 
-It would be much better to have only one `Map` definition, but due to limitations of Go type system, we need to define separate functions for each type.
+It would be preferable to have only one `Map` definition, but due to limitations of the Go type system, we need to define separate functions for each type.
 
-I'm considering adding code generation for such behaviours in the future. Not yet due to focus on validating core concepts.
+I'm considering adding code generation for such behaviors in the future. This is not yet implemented due to a focus on validating core concepts.
 

--- a/docs/examples/json.md
+++ b/docs/examples/json.md
@@ -4,13 +4,13 @@ title: Marshaling union as JSON
 
 # Marshaling union as JSON
 
-MkUnion provides you with utility function that allows you to marshal and unmarshal union types to JSON, 
-reducing burden of writing custom marshaling and unmarshaling functions for union types.
+MkUnion provides you with utility functions that allow you to marshal and unmarshal union types to JSON, 
+reducing the burden of writing custom marshaling and unmarshaling functions for union types.
 
 - `shared.JSONMarshal[A any](in A) ([]byte, error)`
 - `shared.JSONUnmarshal[A any](data []byte) (A, error)`
 
-Below is an example of how to use those functions and how the output JSON looks like.
+Below is an example of how to use these functions and how the output JSON looks like.
 
 
 ```go title="example/tree_json_test.go"
@@ -21,7 +21,7 @@ import (
 --8<-- "example/tree_json_test.go:8:30"
 ```
 
-Formated JSON output of the example above:
+Formatted JSON output of the example above:
 ```json
 {
   "$type": "example.Branch",
@@ -65,17 +65,17 @@ Formated JSON output of the example above:
 ```
 
 
-There are few things that you can notice in this example:
+There are a few things that you can notice in this example:
 
-- Each union type discriminator field `$type` field that holds the type name, and corresponding key with the name of the type, that holds value of union variant.
-    - This is opinionated way, and library don't allow to change it.
-      I was experimenting with making this behaviour customizable, but it make code and API mode complex, and I prefer to keep it simple, and increase interoperability between different libraries and applications, that way.
+- Each union type has a discriminator field, `$type`, which holds the type name, and a corresponding key with the name of the type, which holds the value of the union variant.
+    - This is an opinionated approach, and the library doesn't allow it to be changed.
+      I was experimenting with making this behavior customizable, but it makes the code and API more complex, and I prefer to keep it simple, thereby increasing interoperability between different libraries and applications.
 
-- Recursive union types are supported, and they are marshaled as nested JSON objects.]
+- Recursive union types are supported and are marshaled as nested JSON objects.
 
-- `$type` don't have to have full package import name, nor type parameter,
+- `$type` doesn't have to have the full package import name, nor type parameter,
   mostly because in `shared.JSONUnmarshal[Tree[int]](json)` you hint that your code accepts `Tree[int]`.
     - I'm considering adding explicit type discriminators like `example.Branch[int]` or `example.Leaf[int]`.
-      It could increase type strictness on client side, BUT it makes generating TypeScript types more complex, and I'm not sure if it's worth it.
+      It could increase type strictness on the client side, but it makes generating TypeScript types more complex, and I'm not sure if it's worth it.
 
-- It's not shown on this example, but you can also reference types and union types from other packages, and serialization will work as expected.
+- It's not shown in this example, but you can also reference types and union types from other packages, and serialization will work as expected.

--- a/docs/examples/state_machine.md
+++ b/docs/examples/state_machine.md
@@ -1,113 +1,113 @@
 ---
 title: State machines and unions
 ---
-# MkUnion and state machines in golang
+# MkUnion and state machines in Go
 
-This document will show how to use `mkunion` to manage application state on example of an Order Service. 
+This document will show how to use `mkunion` to manage application state using the example of an Order Service. 
 You will learn:
 
-- how to model state machines in golang, and find similarities to "__clean architecture__"
-- How to **test state machines** (with fuzzing), and as a bonus you will get mermaid diagrams for free
-- How to **persist state in database** and how optimistic concurrency helps __resolve concurrency conflicts__
-- How to **handle errors** in state machines, and build foundations for __self-healing__ systems
+- how to model state machines in Go, and find similarities to "__clean architecture__"
+- How to **test state machines** (with fuzzing), and as a bonus, you will get mermaid diagrams for free
+- How to **persist state in a database** and how optimistic concurrency helps __resolve concurrency conflicts__
+- How to **handle errors** in state machines and build foundations for __self-healing__ systems
 
 
 ## Working example
 
-As an driving example, we will use e-commerce inspired Order Service that can be in one of the following states:
+As a driving example, we will use an e-commerce inspired Order Service that can be in one of the following states:
 
-- `Pending` - order is created, and is waiting for someone to process it
-- `Processing` - order is being processed, an human is going to pick up items from warehouse and pack them
-- `Cancelled` - order was cancelled, there can be many reason, one of them is that warehouse is out of stock.
-- `Completed` - order is completed, and can be shipped to customer.
+- `Pending` - The order is created and is waiting for someone to process it.
+- `Processing` - The order is being processed; a human is going to pick up items from the warehouse and pack them.
+- `Cancelled` - The order was cancelled. There can be many reasons, one of them being that the warehouse is out of stock.
+- `Completed` - The order is completed and can be shipped to the customer.
 
-Such states, have rules that govern **transitions**, like order cannot be cancelled if it's already completed, and so on.
+Such states have rules that govern **transitions**; for example, an order cannot be cancelled if it's already completed, and so on.
 
-We need to have a wayt to trigger changes in state, like create order that pending for processing, or cancel order. We will call those triggers **commands**.
+We need to have a way to trigger changes in state, like creating an order that is pending for processing, or cancelling an order. We will call these triggers **commands**.
 
-Some of those rules could change in future, and we want to be able to change them without rewriting whole application.
-This also informs us that our design should be open for extensions.
+Some of these rules could change in the future, and we want to be able to change them without rewriting the whole application.
+This also informs us that our design should be open for extension.
 
-Side note, if you want go strait to final code product, then into [example/state/](https://github.com/widmogrod/mkunion/tree/main/example/state) directory and have fun exploring.
+Side note: if you want to go straight to the final code product, then go into the [example/state/](https://github.com/widmogrod/mkunion/tree/main/example/state) directory and have fun exploring.
 
 ## Modeling commands and states
 
-Our example can be represented as state machine that looks like this:
+Our example can be represented as a state machine that looks like this:
 [simple_machine_test.go.state_diagram.mmd](https://github.com/widmogrod/mkunion/tree/main/example/state/simple_machine_test.go.state_diagram.mmd)
 ```mermaid
 --8<-- "example/state/machine_test.go.state_diagram.mmd"
 ```
 
-In this diagram, we can see that we have 5 states, and 6 commands that can trigger transitions between states shown as arrows.
+In this diagram, we can see that we have 5 states and 6 commands that can trigger transitions between states, shown as arrows.
 
-Because this diagram is generated from code, it has names that represent types in golang that we use in implementation. 
+Because this diagram is generated from code, it has names that represent types in Go that we use in the implementation. 
 
-For example `*state.CreateOrderCMD`:
+For example, `*state.CreateOrderCMD`:
 
-- `state` it's a package name
+- `state` is the package name.
 - `CreateOrderCMD` is a struct name in that package.
-- `CMD` suffix it's naming convention, that it's optional, but I find it makes code more readable, and easier to distinguish commands from states.
+- The `CMD` suffix is a naming convention that is optional, but I find it makes the code more readable and easier to distinguish commands from states.
 
 
-Below is a code snippet that demonstrate complete model of **state** and **commands** of Order Service, that we talked about.
+Below is a code snippet that demonstrates a complete model of the **state** and **commands** of the Order Service that we discussed.
 
 **Notice** that we use `mkunion` to group commands and states. (Look for `//go:tag mkunion:"Command"`)
 
-This is one example how union types can be used in golang. 
-Historically in golang it would be very hard to achieve such thing, and it would require a lot of boilerplate code.
-Here interface that group those types is generated automatically. You can focus on modeling your domain.
+This is one example of how union types can be used in Go. 
+Historically in Go, it would be very hard to achieve such a thing, and it would require a lot of boilerplate code.
+Here, the interface that groups these types is generated automatically. You can focus on modeling your domain.
 
 ```go title="example/state/model.go"
 --8<-- "example/state/model.go"
 ```
 
 ## Modeling transitions
-One thing that is missing is implementation of transitions between states. 
-There are few ways to do it. I will show you how to do it using functional approach (think  `reduce` or `map` function).
+One thing that is missing is the implementation of transitions between states. 
+There are a few ways to do it. I will show you how to do it using a functional approach (think `reduce` or `map` function).
 
-Let's name function that we will build `Transition` and define it as:
+Let's name the function that we will build `Transition` and define it as:
 
 ```go
 func Transition(ctx context.Context, dep Dependencies, cmd Command, state State) (State, error)
 ```
 
-Our function has few arguments, let's break them down:
+Our function has a few arguments; let's break them down:
 
-- `ctx` standard golang context, that is used to pass deadlines, and cancelation signals, etc.
-- `dep` encapsulates dependencies like API clients, database connection, configuration, context etc.
-   everything that is needed for complete production implementation.
-- `cmd` it's a command that we want to apply to state, 
-   and it has `Command` interface, that was generate by `mkunion` when it was used to group commands.
-- `state` it's a state that we want to apply our command to and change it, 
-   and it has `State` interface, that was generate similarly to `Command` interface.
+- `ctx` is the standard Go context, which is used to pass deadlines, cancellation signals, etc.
+- `dep` encapsulates dependencies like API clients, database connections, configuration, context, etc.
+   — everything that is needed for a complete production implementation.
+- `cmd` is a command that we want to apply to the state, 
+   and it has the `Command` interface, which was generated by `mkunion` when it was used to group commands.
+- `state` is a state that we want to apply our command to and change, 
+   and it has the `State` interface, which was generated similarly to the `Command` interface.
 
 
-Our function must return either new state, or error when something went wrong during transition, like network error, or validation error.
+Our function must return either a new state or an error if something went wrong during the transition, like a network error or a validation error.
 
-Below is snippet of implementation of `Transition` function for our Order Service:
+Below is a snippet of the implementation of the `Transition` function for our Order Service:
 
 ```go title="example/state/machine.go"
 --8<-- "example/state/machine.go:30:81"
 // ...
-// rest remove for brevity 
+// rest removed for brevity 
 // ...
 ```
 
-You can notice few patterns in this snippet:
+You can notice a few patterns in this snippet:
 
-- `Dependency` interface help us to keep, well  dependencies - well defined, which helps greatly in testability and readability of the code. 
-- Use of generated function `MatchCommandR2` to exhaustively match all commands. 
-  This is powerful, when new command is added, you can be sure that you will get compile time error, if you don't handle it.
-- Validation of commands in done in transition function. Current implementation is simple, but you can use go-validate to make it more robust, or refactor code and introduce domain helper functions or methods to the types.
-- Each command check state to which is being applied using `switch` statement, it ignore states that it does not care about. 
-  Which means as implementation you have to focus only on small bit of the picture, and not worry about rest of the states. 
-  This is also example where non-exhaustive use of `switch` statement is welcome.
+- The `Dependency` interface helps us to keep dependencies well-defined, which greatly helps in testability and readability of the code. 
+- The use of the generated function `MatchCommandR2` to exhaustively match all commands. 
+  This is powerful; when a new command is added, you can be sure that you will get a compile-time error if you don't handle it.
+- Validation of commands is done in the transition function. The current implementation is simple, but you can use go-validate to make it more robust, or refactor the code and introduce domain helper functions or methods to the types.
+- Each command checks the state to which it is being applied using a `switch` statement; it ignores states that it doesn't care about. 
+  This means as an implementer, you have to focus only on a small part of the picture and not worry about the rest of the states. 
+  This is also an example where non-exhaustive use of the `switch` statement is welcome.
 
-Simple, isn't it? Simplicity also comes from fact that we don't have to worry about marshalling/unmarshalling data, working with database, those are things that will be done in other parts of the application, keeping this part clean and focused on business logic.
+Simple, isn't it? Simplicity also comes from the fact that we don't have to worry about marshalling/unmarshalling data or working with the database; those are things that will be done in other parts of the application, keeping this part clean and focused on business logic.
 
-Note: Implementation for educational purposes is kept in one big function, 
-but for large projects it may be better to split it into smaller functions, 
-or define OrderService struct that conforms to visitor pattern interface, that was also generated for you:
+Note: The implementation for educational purposes is kept in one big function, 
+but for large projects, it may be better to split it into smaller functions, 
+or define an `OrderService` struct that conforms to the visitor pattern interface, which was also generated for you:
 
 ```go  title="example/state/model_union_gen.go"
 --8<-- "example/state/model_union_gen.go:11:17"
@@ -116,27 +116,27 @@ or define OrderService struct that conforms to visitor pattern interface, that w
 ## Testing state machines & self-documenting
 Before we go further, let's talk about testing our implementation.
 
-Testing will help us not only ensure that our implementation is correct, but also will help us to document our state machine, 
-and discover transition that we didn't think about, that should or shouldn't be possible.
+Testing will not only help us ensure that our implementation is correct but also help us document our state machine 
+and discover transitions that we didn't think about, that should or shouldn't be possible.
 
-Here is how you can test state machine, in declarative way, using `mkunion/x/machine` package:
+Here is how you can test a state machine in a declarative way, using the `mkunion/x/machine` package:
 
 ```go title="example/state/machine_test.go"
 --8<-- "example/state/machine_test.go:15:151"
 ```
-Few things to notice in this test:
+A few things to notice in this test:
 
-- We use standard go testing
-- We use `machine.NewTestSuite` as an standard way to test state machines
-- We start with describing **happy path**, and use `suite.Case` to define test case.
-- But most importantly, we define test cases using `GivenCommand` and `ThenState` functions, that help in making test more readable, and hopefully self-documenting.
-- You can see use of `ForkCase` command, that allow you to take a definition of a state declared in `ThenState` command, and apply new command to it, and expect new state.
-- Less visible is use of `moq` to generate `DependencyMock` for dependencies, but still important to write more concise code.
+- We use standard Go testing.
+- We use `machine.NewTestSuite` as a standard way to test state machines.
+- We start with describing the **happy path** and use `suite.Case` to define a test case.
+- But most importantly, we define test cases using `GivenCommand` and `ThenState` functions, which help make the test more readable and hopefully self-documenting.
+- You can see the use of the `ForkCase` command, which allows you to take the definition of a state declared in the `ThenState` command, apply a new command to it, and expect a new state.
+- Less visible is the use of `moq` to generate `DependencyMock` for dependencies, but it's still important for writing more concise code.
 
-I know it's subjective, but I find it very readable, and easy to understand, even for non-programmers.
+I know it's subjective, but I find it very readable and easy to understand, even for non-programmers.
 
 ## Generating state diagram from tests
-Last bit is this line at the bottom of the test file:
+The last bit is this line at the bottom of the test file:
 
 ```go title="example/state/machine_test.go"
 if suite.AssertSelfDocumentStateDiagram(t, "machine_test.go") {
@@ -144,27 +144,27 @@ if suite.AssertSelfDocumentStateDiagram(t, "machine_test.go") {
 }
 ```
 
-This code takes all inputs provided in test suit and fuzzy them, apply commands to random states, and records result of those transitions.
+This code takes all inputs provided in the test suite and fuzzes them, applies commands to random states, and records the results of those transitions.
 
- - `SelfDocumentStateDiagram` - produce two `mermaid` diagrams, that show all possible transitions that are possible in our state machine.
- - `AssertSelfDocumentStateDiagram` can be used to compare new generated diagrams to diagrams committed in repository, and fail test if they are different.
-   You don't have to use it, but it's good practice to ensure that your state machine is well tested and don't regress without you noticing.
+ - `SelfDocumentStateDiagram` - produces two `mermaid` diagrams that show all possible transitions that are possible in our state machine.
+ - `AssertSelfDocumentStateDiagram` can be used to compare newly generated diagrams to diagrams committed to the repository and fail the test if they are different.
+   You don't have to use it, but it's good practice to ensure that your state machine is well-tested and doesn't regress without you noticing.
 
 
 There are two diagrams that are generated.
 
-One is a diagram of ONLY successful transitions, that you saw at the beginning of this post.
+One is a diagram of ONLY successful transitions that you saw at the beginning of this post.
 
 ```mermaid 
 --8<-- "example/state/machine_test.go.state_diagram.mmd"
 ```
 
-Second is a diagram that includes commands that resulted in an errors:
+Second is a diagram that includes commands that resulted in errors:
 ```mermaid 
 --8<-- "example/state/machine_test.go.state_diagram_with_errors.mmd"
 ```
 
-Those diagrams are stored in the same directory as test file, and are prefixed with name used in `AssertSelfDocumentStateDiagram` function.
+Those diagrams are stored in the same directory as the test file and are prefixed with the name used in the `AssertSelfDocumentStateDiagram` function.
 ```
 machine_test.go.state_diagram.mmd
 machine_test.go.state_diagram_with_errors.mmd
@@ -172,18 +172,18 @@ machine_test.go.state_diagram_with_errors.mmd
 
 ## State machines builder
 
-MkUnion provide `*machine.Machine[Dependency, Command, State]` struct that wires Transition, dependencies and state together.
-It provide methods like:
+MkUnion provides a `*machine.Machine[Dependency, Command, State]` struct that wires the Transition, dependencies, and state together.
+It provides methods like:
 
-- `Handle(ctx context.Context, cmd C) error` that apply command to state, and return error if something went wrong during transition.
-- `State() S` that return current state of the machine
-- `Dep() D` that return dependencies that machine was build with.
+- `Handle(ctx context.Context, cmd C) error` that applies a command to the state and returns an error if something went wrong during the transition.
+- `State() S` that returns the current state of the machine.
+- `Dep() D` that returns the dependencies the machine was built with.
 
 
-This standard helps build on top of it, for example testing library that we use in [Testing state machines & self-documenting](#testing-state-machines-self-documenting) leverage it.
+This standard helps build on top of it; for example, the testing library we use in [Testing state machines & self-documenting](#testing-state-machines-self-documenting) leverages it.
 
-Another good practice is that every package that defines state machine in the way described here, 
-should provide `NewMachine` function that will return bootstrapped machine with package types, like so:
+Another good practice is that every package that defines a state machine in the way described here 
+should provide a `NewMachine` function that will return a bootstrapped machine with package types, like so:
 
 ```go title="example/state/machine.go"
 --8<-- "example/state/machine.go:9:12"
@@ -191,16 +191,16 @@ should provide `NewMachine` function that will return bootstrapped machine with 
 
 ## Conclusion
 
-Now we have all pieces in place, and we can start building our application.
+Now we have all the pieces in place, and we can start building our application.
 
-- We have NewMachine constructor that will give us object to use in our application.
-- We have tests that will ensure that our state machine is correct, fuzzy test help to discover edge cases, and lastly we get diagrams showing which path we tested and cover.
-- We saw how this approach focus on business logic, and keep it separate from other concerns like database, or API clients. Which is one of the principles of clean architecture.
+- We have a `NewMachine` constructor that will give us an object to use in our application.
+- We have tests that will ensure that our state machine is correct; fuzzy tests help discover edge cases, and lastly, we get diagrams showing which paths we tested and covered.
+- We saw how this approach focuses on business logic and keeps it separate from other concerns like the database or API clients. This is one of the principles of clean architecture.
 
 ## Next steps
 
-- **[Persisting union in database](../examples/state_storage.md)** will help answer question how to persist state in database, and how to handle concurrency conflicts
-- **[Handling errors in state machines](../examples/state_storage.md)** will help answer question how to handle errors in state machines, and how to build self-healing systems
+- **[Persisting union in database](../examples/state_storage.md)** will help answer the question of how to persist state in a database and how to handle concurrency conflicts.
+- **[Handling errors in state machines](../examples/state_storage.md)** will help answer the question of how to handle errors in state machines and how to build self-healing systems.
 
 
 

--- a/docs/examples/state_storage.md
+++ b/docs/examples/state_storage.md
@@ -3,21 +3,19 @@ title: Persisting union in database
 ---
 ## Persisting state in database
 
-TODO complete description!
+At this point, we have implemented and tested the Order Service state machine.
 
-At this point of time, we have implemented and tested Order Service state machine.
+The next thing that we need to address on our road to production is to persist state in a database.
 
-Next thing that we need to address in our road to the production is to persist state in database.
+MkUnion aims to support you in this task by providing you with the `x/storage/schemaless` package that will take care of:
 
-MkUnion aims to support you in this task, by providing you `x/storage/schemaless` package that will take care of:
-
-- mapping  golang structs to database representation and back from database to struct.
+- mapping Go structs to database representation and back from the database to a struct.
 - leveraging optimistic concurrency control to resolve conflicts
-- providing you with simple API to work with database
+- providing you with a simple API to work with the database
 - and more
 
-Below is test case that demonstrate complete example of initializing database,
-building an state using `NewMachine` , and saving and loading state from database.
+Below is a test case that demonstrates a complete example of initializing a database,
+building a state using `NewMachine`, and saving and loading state from the database.
 
 ```go title="example/state/machine_database_test.go"
 --8<-- "example/state/machine_database_test.go:16:46"
@@ -37,7 +35,7 @@ sequenceDiagram
     deactivate Store
     
     R->>R: Create machine with state
-    R->>R: Apply command on a state
+    R->>R: Apply command to state
     
     R->>Store: Save state in database under request.ObjectId
     activate Store
@@ -47,43 +45,43 @@ sequenceDiagram
     deactivate R
 ```
 
-Example implementation of such sequence diagram:
+Example implementation of such a sequence diagram:
 
 ```go
-func Handle(rq Request, response Resopnse) {
+func Handle(rq Request, response Response) { // Assuming Resopnse was a typo for Response
 	ctx := rq.Context()
 	
-	// extract objectId and command from request + do some validation
+	// extract `objectId` and `command` from the request and perform some validation
     id := rq.ObjectId
 	command := rq.Command
 	
-    // Load state from store
+    // Load the state from the store
     state, err := store.Find(ctx, id)
 	if err != nil { /*handle error*/ }
 
     machine := NewSimpleMachineWithState(Transition, state)
-    newState, err := machine.Apply(cmd, state)
+    newState, err := machine.Apply(command, state) // cmd was used before, assuming command
     if err != nil { /*handle error*/ }
 	
-    err := store.Save(ctx, newState)
+    err = store.Save(ctx, newState) // Assuming missing =
     if err != nil { /*handle error*/ }
 	
-	// serialize response
+	// serialize the response
 	response.Write(newState)
 }
 ```
 
 ## Error as state. Self-healing systems.
-In request-response situation, handing errors is easy, but what if in some long-lived process something goes wrong?
-How to handle errors in such situation? Without making what we learn about state machines useless or hard to use?
+In a request-response situation, handling errors is easy, but what if something goes wrong in some long-lived process?
+How should errors be handled in such a situation? Without making what we've learned about state machines useless or hard to use?
 
 One solution is to treat errors as state.
-In such case, our state machines will never return error, but instead will return new state, that will represent error.
+In such a case, our state machines will never return an error, but instead will return a new state that will represent an error.
 
-When we introduce explicit command responsible for correcting RecoverableError, we can create self-healing systems.
-Thanks to that, even in situation when errors are unknown, we can retroactivly introduce self-healing logic that correct states.
+When we introduce an explicit command responsible for correcting `RecoverableError`, we can create self-healing systems.
+Thanks to that, even in situations where errors are unknown, we can retroactively introduce self-healing logic that corrects states.
 
-Because there is always there is only one error state, it makes such state machines easy to reason about.
+Since there is always only one error state, it makes such state machines easy to reason about.
 
 ```go
 //go:generate mkunion -name State
@@ -103,10 +101,10 @@ type (
 )
 ```
 
-Now, we have to implement recoverable logic in our state machine.
-We show example above how to do it in `Transition` function.
+Now, we have to implement the recoverable logic in our state machine.
+The example above shows how to do it in the `Transition` function.
 
-Here is example implementation of such transition function:
+Here is an example implementation of such a transition function:
 
 ```go
 func Transition(cmd Command, state State) (State, error) {
@@ -119,55 +117,57 @@ return MustMatchCommandR2(
             state.RetryCount = state.RetryCount + 1
 			
             // here we can do some self-healing logic
-            if state.ErrCode == DuplicateServiceUnavailable {
-                newState, err := Transition(&MarkAsDuplicateCMD{}, state.PrevState)
+            if state.ErrCode == DuplicateServiceUnavailable { // Assuming DuplicateServiceUnavailable is a defined error code
+                newState, err := Transition(&MarkAsDuplicateCMD{}, state.PrevState) // Assuming MarkAsDuplicateCMD is a defined command
                  if err != nil {
-                    // we failed to correct error, so we return error state 
+                    // we failed to correct the error, so we return an error state 
                      return &RecoverableError{
-                        ErrCode: err,
-                        PrevState: state.PrevState,
+                        ErrCode:    0, // Consider setting a more specific error code from 'err'
+                        PrevState:  state.PrevState,
                         RetryCount: state.RetryCount,
                     }, nil
                 }
 				
-                 // we manage to fix state, so we return new state
+                 // we managed to fix the state, so we return new state
                  return newState, nil
              } else {
-                 // log information that we have new code, that we don't know how to handle
+                 // log information that we have a new error code that we don't know how to handle
              }
 			
-            // try to correct error in next iteration
+            // try to correct the error in the next iteration
             return state, nil
         }
-    }
+        return state, nil // Added default return for the switch
+    },
+) // Assuming MustMatchCommandR2 is a function that requires this closing parenthesis
 }
 ```
 
-Now, to correct states we have to select from database all states that are in error state.
-It can be use in many ways, example below use a abstraction called `TaskQueue` that is responsible for running tasks in background.
+Now, to correct states, we have to select all states that are in an error state from the database.
+It can be used in many ways; the example below uses an abstraction called `TaskQueue` that is responsible for running tasks in the background.
 
-This abstraction guaranties that all records (historical and new ones) will be processed.
-You can think about it, as a queue that is populated by records from database, that meet SQL query criteria.
+This abstraction guarantees that all records (historical and new ones) will be processed.
+You can think of it as a queue that is populated by records from the database that meet SQL query criteria.
 
-You can use CRON job and pull database.
+You can use a CRON job and poll the database.
 
 ```go
 //go:generate mms deployyml -type=TaskQueue -name=CorrectMSPErrors -autoscale=1,10 -memory=128Mi -cpu=100m -timeout=10s -schedule="0 0 * * *"
 func main()
-    sql := "SELECT * FROM ObjectState WHERE RecoverableError.RetryCount < 3"
-    store := datalayer.DefaultStore()
-    queue := TaskQueueFrom("correct-msp-errors", sql, store)
-    queue.OnTask(func (ctx context.Context, task Task) error {
+    sql := "SELECT * FROM ObjectState WHERE RecoverableError.RetryCount < 3" // Assuming ObjectState is the table
+    store := datalayer.DefaultStore() // Assuming datalayer.DefaultStore() is available
+    queue := TaskQueueFrom("correct-msp-errors", sql, store) // Assuming TaskQueueFrom is available
+    queue.OnTask(func (ctx context.Context, task Task) error { // Assuming Task type is defined
         state := task.State()
         cmd := &CorrectStateCMD{}
         machine := NewSimpleMachineWithState(Transition, state)
-        newState, err := machine.Apply(cmd, state)
+        newState, err := machine.Apply(cmd, state) // machine.Apply might need context
         if err != nil {
             return err
         }
-        return task.Save(ctx, newState)
+        return task.Save(ctx, newState) // Assuming task.Save is available
     })
-    err := queue.Run(ctx)
+    err := queue.Run(ctx) // Assuming ctx is defined
     if err != nil {
         log.Panic(err)
     }
@@ -176,40 +176,40 @@ func main()
 
 
 ## State machines and command queues and workflows
-What if command would initiate state "to process" and save it in db
-What if task queue would take such state and process it
-Woudn't this be something like command queue?
+What if a command would initiate a state "to process" and save it in the database?
+What if a task queue would take such a state and process it?
+Wouldn't this be something like a command queue?
 
-When to make a list of background processes that transition such states?
+Under what conditions should background processes be used to transition these states?
 
-### processors per state
-It's like micromanage TaskQueue, where each state has it's own state, and it knows what command to apply to given state
-This could be good starting point, when there is not a lot of good tooling
+### Processors per state
+It's like micromanaging the TaskQueue, where each state has its own logic and knows what command to apply to a given state.
+This could be a good starting point when there isn't a lot of good tooling.
 
-### processor for state machine
-With good tooling, transition of states can be declared in one place,
-and deployment to task queue could be done automatically.
+### Processor for state machine
+With good tooling, the transition of states can be declared in one place,
+and deployment to the task queue could be done automatically.
 
-Note, that only some of the transitions needs to happen in background, other can be done in request-response manner.
+Note that only some of the transitions need to happen in the background; others can be done in a request-response manner.
 
-### processor for state machine with workflow
-State machine could be generalized to workflow.
-We can think about it as set of generic Command and State (like a turing machine).
+### Processor for state machine with workflow
+A state machine could be generalized to a workflow.
+We can think about it as a set of generic Commands and States (like a Turing machine).
 
-States like Pending, Completed, Failed
-Commands like Process, Retry, Cancel
+States like `Pending`, `Completed`, `Failed`.
+Commands like `Process`, `Retry`, `Cancel`.
 
-And workflow DSL with commands like: Invoke, Choose, Assign
-Where function is some ID string, and functions needs to be either
-pulled from registry, or called remotely (InvokeRemote).
-some operations would require callback (InvokeAndAwait)
+And a workflow DSL with commands like: `Invoke`, `Choose`, `Assign`.
+Where a function is some ID string, and functions need to be either
+pulled from a registry or called remotely (`InvokeRemote`).
+Some operations would require a callback (`InvokeAndAwait`).
 
-Then background processor would be responsible for executing such workflow (using task queue)
-Program would be responsible for defining workflow, and registering functions.
+Then a background processor would be responsible for executing such a workflow (using a task queue).
+The program would be responsible for defining the workflow and registering functions.
 
-Such programs could be also optimised for deployment,
-if some function would be better to run on same machine that do RPC call
-like function doing RPC call to database, and caching result in memory or in cache cluster dedicated to specific BFF
+Such programs could also be optimized for deployment,
+if some function would be better to run on the same machine that makes an RPC call,
+like a function making an RPC call to a database and caching the result in memory or in a cache cluster dedicated to a specific BFF.
 
 
 

--- a/docs/examples/type_script.md
+++ b/docs/examples/type_script.md
@@ -4,8 +4,14 @@ title: End-to-End types between Go and TypeScript
 
 # End-to-End types between Go and TypeScript
 
-TODO description of generating TypeScript Definitions from using MkUnion
+MkUnion enables the generation of TypeScript definitions directly from your Go union types. This facilitates end-to-end type safety when building applications with a Go backend and a TypeScript frontend.
+
+By using the `mkunion` tool, you can ensure that the data structures exchanged between your Go server and TypeScript client are consistent, reducing the likelihood of integration errors and improving developer experience.
+
+The following snippet shows an example of Go code from which TypeScript definitions can be generated:
 
 ```go title="example/my-app/server.go"
 --8<-- "example/my-app/server.go:34:55"
 ```
+
+This generated TypeScript code can then be imported into your frontend project, providing compile-time checks and autocompletion for your API responses and requests.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,8 +7,8 @@ go install github.com/widmogrod/mkunion/cmd/mkunion@latest
 ```
 
 ### Define your first union type
-Create your first union. In our simple example we will represent different types of vehicles.
-But in a more complex example you may want to represent different states of your application, model domain aggregates, or create your own DSL.
+Create your first union. In our simple example, we will represent different types of vehicles.
+But in a more complex example, you may want to represent different states of your application, model domain aggregates, or create your own DSL.
 ```go title="example/vehicle.go"
 package example
 
@@ -29,12 +29,12 @@ type (
 )
 ```
 
-In above example you can see a few important concepts:
+In the above example, you can see a few important concepts:
 
 #### `//go:tag mkunion:"Vehicle"`
 
-Tag are powerful and flexible way to add metadata to your code.
-You may be familiar with tags when you work with JSON in golang
+Tags are a powerful and flexible way to add metadata to your code.
+You may be familiar with tags when you work with JSON in Go:
 
 ```go
 type User struct {
@@ -42,65 +42,65 @@ type User struct {
 }
 ```
 
-Unfortunately Golang don't extend this feature to other parts of the language.
+Unfortunately, Go doesn't extend this feature to other parts of the language.
 
-MkUnion defines `//go:tag` comment, following other idiomatic definitions `go:generate`, `go:embed` to allow to add metadata to struct type.
-And MkUnion use it heavily to offer way of adding new behaviour to go types.
+MkUnion defines the `//go:tag` comment, following other idiomatic definitions like `go:generate` and `go:embed`, to allow adding metadata to struct types.
+And MkUnion uses it heavily to offer a way of adding new behavior to Go types.
 
 ##### Tags supported by MkUnion
 
-- `go:tag mkunion:"Vehicle"` - define union type
-- `go:tag serde:"json"` - enable serialisation type (currently only JSON is supported), enabled by default
-- `go:tag shape:"-"` - disable shape generation for this type, useful in cases x/shared package cannot depend on other x packages, to avid circular dependencies
-- `go:tag mkunion:",no-type-registry"` - if you want to disable generation type registry in a package, in one of go files above package declaration define tag
-	```go
-	//go:tag mkunion:",no-type-registry"
-	package example
-	```
+- `go:tag mkunion:"Vehicle"` - defines a union type.
+- `go:tag serde:"json"` - enables serialization type (currently only JSON is supported), enabled by default.
+- `go:tag shape:"-"` - disables shape generation for this type, useful in cases where an x/shared package cannot depend on other x packages, to avoid circular dependencies.
+- `go:tag mkunion:",no-type-registry"` - if you want to disable generation of the type registry in a package, define this tag in one of the Go files above the package declaration:
+  ```go
+  //go:tag mkunion:",no-type-registry"
+  package example
+  ```
 - `go:tag mkmatch:""` - generate custom pattern matching function from interface definition
-	```go title="example/vehicle.go"
-	//go:tag mkmatch:"MatchPairs"
-	type MatchPairs[A, B Vehicle] interface {
-		MatchCars(x, y *Car)
-		MatchBoatAny(x *Boat, y any)
-		Finally(x, y any)
-	}
-	```
+  ```go title="example/vehicle.go"
+  //go:tag mkmatch:"MatchPairs"
+  type MatchPairs[A, B Vehicle] interface {
+      MatchCars(x, y *Car)
+      MatchBoatAny(x *Boat, y any)
+      Finally(x, y any)
+  }
+  ```
 
 #### `type (...)` convention
 
-Union type is defined as a set of types in a single type declaration. You can think of it as "one of" type.
-To make it more readable, as convention I decided to use `type (...)` declaration block, instead of individual `type` declaration.
+A union type is defined as a set of types in a single type declaration. You can think of it as a "one of" type.
+To make it more readable, as a convention, I decided to use the `type (...)` declaration block instead of individual `type` declarations.
 
 ### Generate code and watch for changes
 
-Run in your terminal to generate union type for your code and watch for changes
+Run in your terminal to generate union types for your code and watch for changes:
 ```
 mkunion watch ./...
 ```
 
-To generate unions without watching for changes, you can run
+To generate unions without watching for changes, you can run:
 ```
 mkunion watch -g ./...
 ```
 
-Alternatively you can run `mkunion` command directly
+Alternatively, you can run the `mkunion` command directly:
 ```
 mkunion -i example/vehicle.go
 ```
 
 
 #### What order you should run `mkunion watch` and `go generate`?
-First run `mkunion watch ./...` to generate union types, and then run `go generate ./...` to generate code that uses union types.
+First, run `mkunion watch ./...` to generate union types, and then run `go generate ./...` to generate code that uses union types.
 
-I found that this order works best, especially with extension like `moq` that will fail to generate mocks when an type is not defined, which is the case for union types, unit you run `mkunion watch`.
+I found that this order works best, especially with extensions like `moq` that will fail to generate mocks when a type is not defined, which is the case for union types, until you run `mkunion watch`.
 
 ### Match over union type
-When you run `mkunion` command, it will generate file alongside your original file with `union_gen.go` suffix (example [vehicle_union_gen.go](https://github.com/widmogrod/mkunion/tree/main/example/vehicle_union_gen.go))
+When you run the `mkunion` command, it will generate a file alongside your original file with the `union_gen.go` suffix (example [vehicle_union_gen.go](https://github.com/widmogrod/mkunion/tree/main/example/vehicle_union_gen.go)).
 
-You can use those function to do exhaustive matching on your union type.
+You can use these functions to do exhaustive matching on your union type.
 
-For example, you can calculate fuel usage for different types of vehicles, with function that looks like this:
+For example, you can calculate fuel usage for different types of vehicles with a function that looks like this:
 
 ```go title="example/vehicle.go"
 func CalculateFuelUsage(v Vehicle) int {
@@ -119,12 +119,12 @@ func CalculateFuelUsage(v Vehicle) int {
 }
 ```
 
-And as you can see, it leverage generics to make it easy to write.
-No need to cast, or check type, or use `switch` statement.
+And as you can see, it leverages generics to make it easy to write.
+No need to cast, check types, or use `switch` statements.
 
 #### matching functions `Match{Name}R1`
 Where `Name` is the name of your union type.
-Where `R0`, `R1`, `R2`, `R3` stands for number of return values.
+Where `R0`, `R1`, `R2`, `R3` stand for the number of return values.
 
 Example of `MatchVehicleR1` function signature:
 ```go
@@ -140,8 +140,8 @@ func MatchVehicleR1[T0 any](
 
 ### JSON marshalling
 
-MkUnion also generate JSON marshalling functions for you.
-You just need to use `shared.JSONMarshal` and `shared.JSONUnmarshal` functions to marshal and unmarshal your union type.
+MkUnion also generates JSON marshalling functions for you.
+You just need to use the `shared.JSONMarshal` and `shared.JSONUnmarshal` functions to marshal and unmarshal your union type.
 
 Example:
 
@@ -164,7 +164,7 @@ func ExampleVehicleToJSON() {
 }
 ```
 
-You can notice that it has opinionated way of marshalling and unmarshalling your union type.
-It uses `$type` field to store type information, and then store actual data in separate field, with corresponding name.
+You can notice that it has an opinionated way of marshalling and unmarshalling your union type.
+It uses the `$type` field to store type information, and then stores the actual data in a separate field with the corresponding name.
 
-You can read more about it in [Marshaling union in JSON](./examples/json.md) section.
+You can read more about it in the [Marshaling union in JSON](./examples/json.md) section.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,17 +13,17 @@ Strongly typed **union type** in golang that supports generics*
 
 * with exhaustive _pattern matching_ support
 * with _json marshalling_ including generics
-* and as a bonus, can generate compatible typescript types for end-to-end type safety in your application
+* and as a bonus, can generate compatible TypeScript types for end-to-end type safety in your application
 
 ## Why
-Historically in languages without union types like golang, unions were solved either by using Visitor pattern, or using `iota` and `switch` statement, or other workarounds.
+Historically, in languages like Go that lack native union types, developers have resorted to workarounds such as the Visitor pattern or `iota` with `switch` statements.
 
-Visitor pattern requires a lot of boiler plate code and hand crafting of the `Accept` method for each type in the union.
-`iota` and `switch` statement is not type safe and can lead to runtime errors, especially when new type is added and not all `case` statements are updated.
+The Visitor pattern requires a lot of boilerplate code and manual crafting of the `Accept` method for each type in the union.
+Using `iota` and `switch` statements is not type-safe and can lead to runtime errors, especially when a new type is added and not all `case` statements are updated.
 
-On top of that, any data marshalling like to/from JSON requires additional, hand crafted code, to make it work.
+On top of that, any data marshalling, like to/from JSON, requires additional, handcrafted code to make it work.
 
-MkUnion solves all of those problems, by generating opinionated and strongly typed meaningful code for you.
+MkUnion solves all of these problems by generating opinionated and strongly typed, meaningful code for you.
 
 ## Example
 

--- a/x/machine/README.md
+++ b/x/machine/README.md
@@ -181,7 +181,7 @@ sequenceDiagram
 Example implementation of such a sequence diagram:
 
 ```go
-func Handle(rq Request, response Response) { // Corrected typo: Resopnse -> Response
+func Handle(rq Request, response Response) { 
 	ctx := rq.Context()
 	
 	// extract `objectId` and `command` from the request and perform some validation
@@ -193,10 +193,10 @@ func Handle(rq Request, response Response) { // Corrected typo: Resopnse -> Resp
 	if err != nil { /*handle error*/ }
 
     machine := NewSimpleMachineWithState(Transition, state)
-    newState, err := machine.Apply(command, state) // Use 'command' variable
+    newState, err := machine.Apply(command, state) 
     if err != nil { /*handle error*/ }
 	
-    err = store.Save(ctx, newState) // Add missing '='
+    err = store.Save(ctx, newState) 
     if err != nil { /*handle error*/ }
 	
 	// serialize the response
@@ -241,38 +241,38 @@ Here is an example implementation of such a transition function:
 
 ```go
 func Transition(cmd Command, state State) (State, error) {
-return MustMatchCommandR2(
-    cmd,
-    /* ... */
-    func(cmd *CorrectStateCMD) (State, error) {
-        switch state := state.(type) {
-        case *RecoverableError:
-            state.RetryCount = state.RetryCount + 1
-			
-            // here we can do some self-healing logic
-            if state.ErrCode == DuplicateServiceUnavailable { // Assuming DuplicateServiceUnavailable is a defined error code
-                newState, err := Transition(&MarkAsDuplicateCMD{}, state.PrevState) // Assuming MarkAsDuplicateCMD is a defined command
-                 if err != nil {
-                    // we failed to correct the error, so we return an error state 
-                     return &RecoverableError{
-                        ErrCode:    0, // Consider setting a more specific error code from 'err'
-                        PrevState:  state.PrevState,
-                        RetryCount: state.RetryCount,
-                    }, nil
-                }
-				
-                 // we managed to fix the state, so we return new state
-                 return newState, nil
-             } else {
-                 // log information that we have a new error code that we don't know how to handle
-             }
-			
-            // try to correct the error in the next iteration
-            return state, nil
-        }
-        return state, nil // Added default return for the switch
-    },
-) // Assuming MustMatchCommandR2 is a function that requires this closing parenthesis
+    return MustMatchCommandR2(
+        cmd,
+        /* ... */
+        func(cmd *CorrectStateCMD) (State, error) {
+            switch state := state.(type) {
+            case *RecoverableError:
+                state.RetryCount = state.RetryCount + 1
+                
+                // here we can do some self-healing logic
+                if state.ErrCode == DuplicateServiceUnavailable { // DuplicateServiceUnavailable is a defined error code
+                    newState, err := Transition(&MarkAsDuplicateCMD{}, state.PrevState) 
+                     if err != nil {
+                        // we failed to correct the error, so we return an error state 
+                         return &RecoverableError{
+                            ErrCode:    0, // Consider setting a more specific error code from 'err'
+                            PrevState:  state.PrevState,
+                            RetryCount: state.RetryCount,
+                        }, nil
+                    }
+                    
+                     // we managed to fix the state, so we return new state
+                     return newState, nil
+                 } else {
+                     // log information that we have a new error code that we don't know how to handle
+                 }
+                
+                // try to correct the error in the next iteration
+                return state, nil
+            }
+            return state, nil // Added default return for the switch
+        },
+    )
 }
 ```
 

--- a/x/shape/README.md
+++ b/x/shape/README.md
@@ -1,6 +1,6 @@
 # x/shape
-Package provides representation of types.
+The package provides representation of types.
 
-It's use in mkunion for example to extract union types and generate TypeScript schema for them.
-Such schema generation is useful in building application that have end-to-end type safety.
+It's used in mkunion, for example, to extract union types and generate TypeScript schema for them.
+Such schema generation is useful in building applications that have end-to-end type safety.
 

--- a/x/storage/README.md
+++ b/x/storage/README.md
@@ -1,6 +1,6 @@
-# x/storage - Golang schemaless orm with union type support
-Make working with data types in golang easy and simple. 
-Focus on business logic, that differentiate your needs, not serialization and deserialization.
+# x/storage - Go schemaless ORM with union type support
+Make working with data types in Go easy and simple. 
+Focus on business logic that differentiates your needs, not on serialization and deserialization.
 
 
 ```go
@@ -13,7 +13,7 @@ store := schemaless.NewInMemoryRepository()
 //store := schemaless.NewDynamoDBRepository(dynamodb.NewFromConfig(cfg), tableName)
 //store := NewOpenSearchRepository(client, indexName)
 
-// make working with records type safe
+// Make working with records type-safe
 repo := typedful.NewTypedRepository[MyRecord](store)
 state, err := repo.Get("1", "user")
 assert.ErrorIs(t, err, schemaless.ErrNotFound)

--- a/x/taskqueue/README.md
+++ b/x/taskqueue/README.md
@@ -1,1 +1,1 @@
-# x/taskqueue - Golang task queue with transactional support
+# x/taskqueue - Go task queue with transactional support

--- a/x/workflow/README.md
+++ b/x/workflow/README.md
@@ -1,6 +1,6 @@
-# x/workflow - manage workflows in transactional way
+# x/workflow - manage workflows in a transactional way
 
-When you find yourself that you have to do two or more write operation in one operation, you may find this library helpful.
+When you find that you have to do two or more write operations in a single logical operation, you may find this library helpful.
 
 ```go
 flow RegisterUser(input) {
@@ -136,14 +136,14 @@ for _, flow := range flows {
 }
 ```
 
-- Functions must be idempotent. Runtime will always provide unique to operation call ID, so function or middleware needs to deduplicate it
+- Functions must be idempotent. The runtime will always provide a unique-to-operation call ID, so the function or middleware needs to deduplicate it.
 
 ## Roadmap
 ### Ideas
-- [ ] proof of concept with simple ui to explore failed states 
-- [ ] generate from program logic, functions to be implemented
-- [ ] deployment planner, allow to deploy function as embedded (wasm) or remote with autoscaling rules
-- [ ] background processing logic (pull base)
-- [ ] background processing logic stream based
-- [ ] generate functions from OpenAPI, gRPC spec
-- [ ] lang server with autocomplete
+- [ ] Proof of concept with a simple UI to explore failed states
+- [ ] Generate from program logic, functions to be implemented
+- [ ] Deployment planner, allowing functions to be deployed as embedded (Wasm) or remote with autoscaling rules
+- [ ] Background processing logic (pull-based)
+- [ ] Background processing logic (stream-based)
+- [ ] Generate functions from OpenAPI, gRPC spec
+- [ ] Language server with autocomplete


### PR DESCRIPTION
This commit addresses numerous typos, grammatical errors, and clarity improvements across a wide range of documentation files.
