### PR TITLE
fix: correct subscriber removal in PubSubChan to prevent deadlock

### DIFF
--- a/x/storage/schemaless/projection/pub_sub_chan.go
+++ b/x/storage/schemaless/projection/pub_sub_chan.go
@@ -151,7 +151,7 @@ func (s *PubSubChan[T]) Subscribe(f func(T) error) error {
 	newSubscribers := make([]*subscriber[T], 0, len(s.subscribers)-1)
 	for _, su := range s.subscribers {
 		if su != sub {
-			newSubscribers = append(newSubscribers, sub)
+			newSubscribers = append(newSubscribers, su)
 		}
 	}
 	s.subscribers = newSubscribers


### PR DESCRIPTION
## Summary
- Fixed critical bug in `PubSubChan.Subscribe()` that was causing deadlocks in `TestPubSubChan`
- Changed line 154 to append the correct variable (`su` instead of `sub`)

## Details
The bug was in the subscriber removal logic where we were incorrectly appending the subscriber being removed (`sub`) instead of the other subscribers (`su`) when rebuilding the subscriber list. This caused:
- Corrupted subscriber list with duplicate entries
- Lost references to other subscribers  
- Potential deadlocks during cleanup

## Test plan
- [x] Verified `TestPubSubChan` now passes consistently
- [x] Ran test 5 times with `go test -v -count=5` to ensure no flakiness
- [x] All tests in the projection package pass

Fixes #158

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where unsubscribed users were not properly removed from the subscriber list, ensuring accurate management of active subscribers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->