### PR TITLE
feat: Add automatic go generate execution to mkunion watch command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,18 +24,22 @@ go install github.com/widmogrod/mkunion/cmd/mkunion@latest
 
 ### Code Generation Workflow
 ```bash
-# Step 1: Generate union types and shapes (run from project root)
+# Generate union types and shapes, then automatically run go generate (run from project root)
 mkunion watch ./...
 
-# Step 2: Run other code generators that depend on union types
-go generate ./...
-
-# For one-time generation without watching
+# For one-time generation without watching (also runs go generate automatically)
 mkunion watch -g ./...
+
+# Skip running go generate after mkunion generation
+mkunion watch -G ./...
+# or
+mkunion watch --dont-run-go-generate ./...
 
 # Generate TypeScript types
 mkunion shape-export --language typescript --output-dir ./output -i file.go
 ```
+
+**Note:** As of the latest version, `mkunion watch` automatically runs `go generate ./...` after generating union types and shapes. This eliminates the need to run two separate commands. Use the `-G` flag if you want to skip the automatic `go generate` step.
 
 ### Testing
 ```bash


### PR DESCRIPTION
## Summary
This PR implements automatic execution of `go generate ./...` after mkunion generates files, eliminating the need for a two-step process. The feature is enabled by default but can be disabled with the new `--dont-run-go-generate` flag (short form: `-G`).

## Changes
- ✨ Added automatic `go generate` execution after mkunion generation (both initial and on file changes)
- 🎯 Added intelligent detection of directories containing `//go:generate` directives
- 🚫 Added `--dont-run-go-generate` flag (`-G`) to opt out of automatic execution
- 🔇 Filtered out false positive warnings like "matched no packages"
- ⚡ Improved error handling to continue processing other directories on failure
- 📝 Updated documentation to reflect the new workflow

## Implementation Details
- The `runGoGenerate` function pre-scans directories for `//go:generate` directives before execution
- Errors are logged as warnings with specific directory information
- The function continues processing all directories even if some fail
- Output is captured and filtered to reduce noise in logs

## Testing
- Added comprehensive unit tests for the `runGoGenerate` function
- Tests cover success cases, error handling, and edge cases
- All existing tests continue to pass

## Developer Experience Impact
**Before:**
```bash
mkunion watch ./...
go generate ./...
```

**After:**
```bash
mkunion watch ./...  # Automatically runs go generate
```

To maintain previous behavior:
```bash
mkunion watch -G ./...  # Skip go generate
```

Fixes #191