### PR TITLE
docs: improve test documentation and update state machine examples

### DIFF
--- a/docs/examples/simple_state_machines.md
+++ b/docs/examples/simple_state_machines.md
@@ -56,4 +56,3 @@ The traffic light example illustrates fundamental state machine concepts:
 
 - Review the [comprehensive Order Service example](state_machine.md) for a more complex scenario
 - Learn about [testing strategies](state_machine.md#testing-state-machines-self-documenting) for state machines
-- Explore [advanced patterns](state_machine_best_practices.md#advanced-patterns) for composition and async operations

--- a/docs/examples/state_machine.md
+++ b/docs/examples/state_machine.md
@@ -123,7 +123,8 @@ and discover transitions that we didn't think about, that should or shouldn't be
 Here is how you can test a state machine in a declarative way, using the `mkunion/x/machine` package:
 
 ```go title="example/state/machine_test.go"
---8<-- "example/state/machine_test.go:test-suite"
+--8<-- "example/state/machine_test.go:moq-init"
+--8<-- "example/state/machine_test.go:test-suite-happy"
 ```
 A few things to notice in this test:
 
@@ -142,9 +143,7 @@ I know it's subjective, but I find it very readable and easy to understand, even
 The last bit is this line at the bottom of the test file:
 
 ```go title="example/state/machine_test.go"
-if suite.AssertSelfDocumentStateDiagram(t, "machine_test.go") {
-   suite.SelfDocumentStateDiagram(t, "machine_test.go")
-}
+--8<-- "example/state/machine_test.go:doc-assert"
 ```
 
 This code takes all inputs provided in the test suite and fuzzes them, applies commands to random states, and records the results of those transitions.
@@ -205,6 +204,5 @@ For a comprehensive guide on best practices, patterns, and advanced techniques, 
 ## Next steps
 
 - **[State Machine Best Practices](state_machine_best_practices.md)** - Learn about file organization, naming conventions, testing strategies, and advanced patterns
-- **[Simple Examples](simple_state_machines.md)** - Start with basic state machines before tackling complex scenarios
 - **[Persisting union in database](../examples/state_storage.md)** - Learn how to persist state in a database and handle concurrency conflicts
 - **[Handling errors in state machines](../examples/state_storage.md)** - Build self-healing systems by treating errors as states

--- a/example/state/machine_test.go
+++ b/example/state/machine_test.go
@@ -28,6 +28,8 @@ func TestSuite(t *testing.T) {
 		Quantity: 3,
 	}
 
+	// --8<-- [start:test-suite]
+	// --8<-- [start:test-suite-happy]
 	suite := machine.NewTestSuite(di, NewMachine)
 	suite.Case(t, "happy path of order state transition",
 		func(t *testing.T, c *machine.Case[Dependency, Command, State]) {
@@ -69,6 +71,7 @@ func TestSuite(t *testing.T) {
 									},
 								})
 						}).
+						// --8<-- [end:test-suite-happy]
 						ForkCase(t, "mark order cannot be by the same worker", func(t *testing.T, c *machine.Case[Dependency, Command, State]) {
 							c.
 								GivenCommand(&MarkOrderCompleteCMD{
@@ -166,16 +169,19 @@ func TestSuite(t *testing.T) {
 												PaymentChargedAt: &now,
 											},
 										})
-									// --8<-- [end:moq-usage]
 								})
+							// --8<-- [end:moq-usage]
 						})
 				})
 		},
 	)
 
+	// --8<-- [start:doc-assert]
 	if suite.AssertSelfDocumentStateDiagram(t, "machine_test.go") {
 		suite.SelfDocumentStateDiagram(t, "machine_test.go")
 	}
+	// --8<-- [end:doc-assert]
+	// --8<-- [end:test-suite]
 }
 
 func TestStorage(t *testing.T) {


### PR DESCRIPTION
- Updated `simple_state_machines.md` and `state_machine.md` to refine example links and remove redundant information.
- Enhanced test suite in `machine_test.go` with additional annotations for better structure and traceability.